### PR TITLE
Custom group ordering

### DIFF
--- a/src/group.jl
+++ b/src/group.jl
@@ -8,7 +8,7 @@ end
 
 # this is when given a vector-type of values to group by
 function _extract_group_attributes(v::AVec, args...; legend_entry = string)
-    group_labels = sort(collect(unique(v)))
+    group_labels = collect(unique(sort(v)))
     n = length(group_labels)
     if n > 100
         @warn("You created n=$n groups... Is that intended?")


### PR DESCRIPTION
This one-line change makes group label extraction
call `sort` before calling `unique` to allow for custom ordering
when given a `CategoricalArray`.
```
ctg = CategoricalArray(["a", "b", "c", "a", "b", "c"])
levels!(ctg, ["c", "b", "a"])

sort(collect(unique(ctg))) == ["a", "b", "c"]
collect(unique(sort(ctg))) == ["c", "b", "a"]
```

See https://github.com/JuliaPlots/StatsPlots.jl/issues/291

EDIT: This relies on `unique` returning elements in the previously sorted order.
Is that guaranteed?