### PR TITLE
Use NaNMath log functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.11"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 PlotUtils = "995b91a9-d308-5afd-9ec6-746e21dbc043"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 

--- a/src/RecipesPipeline.jl
+++ b/src/RecipesPipeline.jl
@@ -5,6 +5,7 @@ import RecipesBase
 import RecipesBase: @recipe, @series, RecipeData, is_explicit
 import PlotUtils # tryrange and adapted_grid
 using Dates
+using NaNMath
 
 export recipe_pipeline!
 # Plots relies on these:

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -193,7 +193,7 @@ needs_3d_axes(plotattributes::AbstractDict) =
 # ## Scales
 # --------------------------------
 
-const SCALE_FUNCTIONS = Dict{Symbol, Function}(:log10 => log10, :log2 => log2, :ln => log)
+const SCALE_FUNCTIONS = Dict{Symbol, Function}(:log10 => NaNMath.log10, :log2 => NaNMath.log2, :ln => NaNMath.log)
 const INVERSE_SCALE_FUNCTIONS =
     Dict{Symbol, Function}(:log10 => exp10, :log2 => exp2, :ln => exp)
 


### PR DESCRIPTION
This means that log-scale plots will skip negative points, instead of giving an error. The following should work:
```julia
using Plots
plot(cumsum(randn(1000,4), dims=1), yaxis=(:log10, [0.1, :auto]))
```
The axes will still not be set automatically to fit only positive points, but it's a start. 

ref https://github.com/JuliaPlots/Plots.jl/issues/1959