### PR TITLE
more friendly error when x,y shape mis-match

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -92,6 +92,11 @@ _nobigs(v) = v
     x = _compute_x(x, y, z)
     y = _compute_y(x, y, z)
     z = _compute_z(x, y, z)
+    if !isnothing(x)
+        n = size(x,1)
+        !isnothing(y) && size(y,1) != n && error("Expects $n elements in each col of y, found $(size(y,1)).")
+        !isnothing(z) && size(z,1) != n && error("Expects $n elements in each col of z, found $(size(z,1)).")
+    end
     _nobigs(x), _nobigs(y), _nobigs(z)
 end
 

--- a/src/series.jl
+++ b/src/series.jl
@@ -92,10 +92,9 @@ _nobigs(v) = v
     x = _compute_x(x, y, z)
     y = _compute_y(x, y, z)
     z = _compute_z(x, y, z)
-    if !isnothing(x)
+    if !isnothing(x) && isnothing(z)
         n = size(x,1)
         !isnothing(y) && size(y,1) != n && error("Expects $n elements in each col of y, found $(size(y,1)).")
-        !isnothing(z) && size(z,1) != n && error("Expects $n elements in each col of z, found $(size(z,1)).")
     end
     _nobigs(x), _nobigs(y), _nobigs(z)
 end


### PR DESCRIPTION
fix https://github.com/JuliaPlots/Plots.jl/issues/3048

```
julia> plot( rand(5), rand(1,5) )
ERROR: Expects 5 elements in each col of y, found 1.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] _compute_xyz(::Array{Float64,1}, ::Array{Float64,1}, ::Nothing) at /home/akako/.julia/dev/RecipesPipeline/src/series.jl:97
```