### PR TITLE
Fix broken histogram and stepbins plotting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecipesPipeline"
 uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
 authors = ["Michael Krabbe Borregaard <mkborregaard@snm.ku.dk>"]
-version = "0.2"
+version = "0.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/series.jl
+++ b/src/series.jl
@@ -94,7 +94,8 @@ _nobigs(v) = v
     z = _compute_z(x, y, z)
     if !isnothing(x) && isnothing(z)
         n = size(x,1)
-        !isnothing(y) && size(y,1) != n && error("Expects $n elements in each col of y, found $(size(y,1)).")
+        # Workaround: Allow y to be one element shorter than x to support binning edges in x, e.g. for histograms
+        !isnothing(y) && (size(y,1) != n && size(y,1) != n - 1) && error("Expects $n elements in each col of y, found $(size(y,1)).")
     end
     _nobigs(x), _nobigs(y), _nobigs(z)
 end


### PR DESCRIPTION
RecipesPipeling v0.2.0 broke things like `plot(::Histogram)` and `plot(x, y, seriestype = :stepbins)`, see JuliaPlots/Plots.jl#3137.

`_compute_xyz` now requires `x` and `y` to be of the same length - so far, for an binning-edge-like `x`, we had allowed a x to be one element longer than y in Plots for `:stepbins` and similar. So this actually breaks backward compatibility in Plots.

This is a quick workaround that allows a length difference of 1 again - we may want to implement something cleaner in the future, but that may then require a Plots.jl v2.

Could this be merged quickly, with a quick release of a RecipesPipeling v0.2.1 (this PR already increases the version number in Project.toml)? Histogram plotting being broken is a serious problem for some people I'm working with right now.