### PR TITLE
don't catch all the MethodErrors

### DIFF
--- a/src/plot_recipe.jl
+++ b/src/plot_recipe.jl
@@ -40,7 +40,6 @@ function _process_plotrecipe(plt, kw, kw_list, still_to_process)
             push!(still_to_process, data.plotattributes)
         end
     catch err
-        @show err
         if err isa MethodError && occursin("plot recipe", err.args)
             push!(kw_list, kw)
         else

--- a/src/plot_recipe.jl
+++ b/src/plot_recipe.jl
@@ -40,7 +40,8 @@ function _process_plotrecipe(plt, kw, kw_list, still_to_process)
             push!(still_to_process, data.plotattributes)
         end
     catch err
-        if isa(err, MethodError)
+        @show err
+        if err isa MethodError && occursin("plot recipe", err.args)
             push!(kw_list, kw)
         else
             rethrow()


### PR DESCRIPTION
This is annoying me every now and then.
Becuase sometimes the error is from something else and doesn't show up