### PR TITLE
Fix `unzip` for empty vectors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,8 +68,13 @@ jobs:
 
       # Run tests
       - name: Run tests
-        run:  |
-          $TESTCMD --project -e 'using Pkg; Pkg.test(coverage=true);'
+        run: $TESTCMD --project -e 'using Pkg; Pkg.test(coverage=true)'
+
+      # Codecov
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v2
+        with:
+          file: lcov.info
 
   Skip:
     if: "contains(github.event.head_commit.message, '[skip ci]')"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -208,7 +208,7 @@ inverse_scale_func(scale::Symbol) =
 # ## Unzip
 # --------------------------------
 
-unzip(v::AVec{<:Tuple}) = tuple((([t[j] for t in v]) for j in 1:length(v[1]))...)
+unzip(v::AVec{<:Tuple}) = map(x->getfield.(v, x), fieldnames(eltype(v)))
 
 # --------------------------------
 # ## Map functions on vectors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,21 +15,32 @@ using StatsPlots
 using Test
 using TestImages
 
-# makie_test_dir = joinpath(@__DIR__, "test_makie")
-# mkpath(makie_test_dir)
+@testset "unzip" begin
+    x, y, z = unzip([(1., 2., 3.), (1., 2., 3.)])
+    @test all(x .== 1.) && all(y .== 2.) && all(z .== 3.)
+    x, y, z = unzip(Tuple{Float64, Float64, Float64}[])
+    @test isempty(x) && isempty(y) && isempty(z)
+end
 
-@testset "RecipesPipeline.jl" begin
-    # @testset "Makie integration" begin cd(makie_test_dir) do
-    #     include("makie.jl")
-    # end end
-    @testset "Plots" begin
-        for i in eachindex(Plots._examples)
-            if i ∉ Plots._backend_skips[:gr]
-                @test Plots.test_examples(:gr, i, disp=false) isa Plots.Plot
-            end
+@testset "group" begin
+    include("test_group.jl")
+end
+
+@testset "plots" begin
+    for i in eachindex(Plots._examples)
+        if i ∉ Plots._backend_skips[:gr]
+            @test Plots.test_examples(:gr, i, disp=false) isa Plots.Plot
         end
     end
-    @testset "Group" begin
-        include("test_group.jl")
+end
+
+#=
+makie_test_dir = joinpath(@__DIR__, "test_makie")
+mkpath(makie_test_dir)
+
+@testset "Makie integration" begin
+    cd(makie_test_dir) do
+        include("makie.jl")
     end
 end
+=#


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/4146.

**performance**
```julia
using BenchmarkTools

unzip1(v) = tuple((([t[j] for t in v]) for j in 1:length(v[1]))...)
unzip2(v) = map(x->getfield.(v, x), fieldnames(eltype(v)))

main() = begin
  a = [Tuple(rand(3)) for _ ∈ 1:1_000_000]
  @btime unzip1($a)
  @btime unzip2($a)
end

main()
```

**output**
```julia
  41.424 ms (6 allocations: 22.89 MiB)
  37.375 ms (6 allocations: 22.89 MiB)
```

We need more unit tests in `RecipesPipeline.jl` !

`nightly` failure is unrelated.