### PR TITLE
update compat bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 [compat]
 NaNMath = "0.3, 1"
 PlotUtils = "0.6.5, 1"
-RecipesBase = "0.8, 1.0"
+RecipesBase = "0.8, 1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
I'm going to bump lower julia compat to `1.6`, since we only test `1.6`+ in ci: declaring a lower compat without testing it is a mistake.