### PR TITLE
fix replacement of Union{Missing,Real} arrays so all missing arrays plot

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,29 @@ using StatsPlots
 using Test
 using TestImages
 
+import RecipesPipeline: _prepare_series_data
+
+@testset "_prepare_series_data" begin
+    @test_throws ErrorException _prepare_series_data(:test)
+    @test _prepare_series_data(nothing) === nothing
+    @test _prepare_series_data((1.0, 2.0)) === (1.0, 2.0)
+    @test _prepare_series_data(identity) === identity
+    @test _prepare_series_data(1:5:10) === 1:5:10
+    a = ones(Union{Missing,Float64}, 100, 100);
+    sd = _prepare_series_data(a)
+    @test sd == a
+    @test eltype(sd) == Float64
+    a .= missing
+    sd = _prepare_series_data(a)
+    @test eltype(sd) == Float64
+    @test all(isnan, sd) 
+    a = fill(missing, 100, 100)
+    sd = _prepare_series_data(a)
+    @test eltype(sd) == Float64
+    @test all(isnan, sd) 
+    # TODO String, Volume etc
+end
+
 @testset "unzip" begin
     x, y, z = unzip([(1., 2., 3.), (1., 2., 3.)])
     @test all(x .== 1.) && all(y .== 2.) && all(z .== 3.)


### PR DESCRIPTION
Currently plotting a heatmap with only missing values fails. Probably other series types too.

This is because `map(float, a)` on line 15 of series.jl - when run over a mixed type array containing only missing values returns an array of eltype `Missing`.

Instead, this PR makes a new array with the correct float type using `similar`, and broadcasts the `ismissing` and `isnan` checks from the old array to the new array. The removed mutability check wasn't actually relevant because map creates a new array anyway every time. So I removed it.

This is the current error solved by the PR. If you know where I should test this, let me know.

```julia

julia> a = ones(Union{Missing,Float64}, 100, 100);

julia> a .= missing;

julia> heatmap(a)
ERROR: MethodError: convert(::Type{Union{}}, ::Float64) is ambiguous. Candidates:
  convert(::Type{T}, x::Number) where T<:Number in Base at number.jl:7
  convert(::Type{T}, x::Number) where T<:AbstractChar in Base at char.jl:184
  convert(::Type{C}, c::Number) where C<:Colorant in ColorTypes at /home/raf/.julia/packages/ColorTypes/1dGw6/src/conversions.jl:74
  convert(::Type{<:Measures.Measure}, x::Float64) in Plots.PlotMeasures at /home/raf/.julia/packages/Plots/OeNV1/src/plotmeasures.jl:12
  convert(::Type{Union{}}, x) in Base at essentials.jl:216
  convert(::Type{T}, geom::X) where {T<:ArchGDAL.IGeometry, X} in ArchGDAL at /home/raf/.julia/packages/ArchGDAL/1I2FZ/src/geointerface.jl:286
  convert(::Type{T}, arg) where T<:VecElement in Base at baseext.jl:19
Possible fix, define
  convert(::Type{Union{}}, ::Float64)
Stacktrace:
  [1] convert(#unused#::Type{Missing}, x::Float64)
    @ Base ./missing.jl:69
  [2] setindex!(A::Matrix{Missing}, x::Float64, i1::Int64)
    @ Base ./array.jl:903
  [3] _replace!(new::RecipesPipeline.var"#100#101", res::Matrix{Missing}, A::Matrix{Missing}, count::Int64)
    @ Base ./set.jl:681
  [4] replace!(new::Function, A::Matrix{Missing}; count::Int64)
    @ Base ./set.jl:531
  [5] replace!
    @ ./set.jl:531 [inlined]
  [6] _prepare_series_data
    @ ~/.julia/dev/RecipesPipeline/src/series.jl:15 [inlined]
  [7] _prepare_series_data
    @ ~/.julia/dev/RecipesPipeline/src/series.jl:20 [inlined]
  [8] _series_data_vector(x::Surface{Matrix{Union{Missing, Float64}}}, plotattributes::Dict{Symbol, Any})
    @ RecipesPipeline ~/.julia/dev/RecipesPipeline/src/series.jl:27
  [9] macro expansion
    @ ~/.julia/dev/RecipesPipeline/src/series.jl:128 [inlined]
 [10] apply_recipe(plotattributes::AbstractDict{Symbol, Any}, #unused#::Type{RecipesPipeline.SliceIt}, x::Any, y::Any, z::Any)
    @ RecipesPipeline ~/.julia/dev/RecipesPipeline/src/series.jl:116
 [11] _process_userrecipes!(plt::Any, plotattributes::Any, args::Any)
    @ RecipesPipeline ~/.julia/dev/RecipesPipeline/src/user_recipe.jl:36
 [12] recipe_pipeline!(plt::Any, plotattributes::Any, args::Any)
    @ RecipesPipeline ~/.julia/dev/RecipesPipeline/src/RecipesPipeline.jl:70
 [13] _plot!(plt::Plots.Plot, plotattributes::Any, args::Any)
    @ Plots ~/.julia/packages/Plots/OeNV1/src/plot.jl:208
 [14] plot(args::Any; kw::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}} where {V, N, names, T<:Tuple{Vararg{Any, N}}})
    @ Plots ~/.julia/packages/Plots/OeNV1/src/plot.jl:91
 [15] heatmap(args::Any; kw::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}} where {V, N, names, T<:Tuple{Vararg{Any, N}}})
    @ Plots ~/.julia/packages/RecipesBase/qpxEX/src/RecipesBase.jl:410
 [16] heatmap(args::Any)
    @ Plots ~/.julia/packages/RecipesBase/qpxEX/src/RecipesBase.jl:410
 [17] top-level scope
    @ REPL[36]:1
```

@evetion this should fix your Rasters.jl plotting problem