### PR TITLE
Support segments

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecipesPipeline"
 uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
 authors = ["Michael Krabbe Borregaard <mkborregaard@snm.ku.dk>"]
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -30,6 +30,15 @@ timeformatter(t) = string(Dates.Time(Dates.Nanosecond(round(t))))
 @recipe f(::Type{P}, t::P) where {P<:Dates.Period} =
     (t -> Dates.value(t), t -> string(P(round(t))))
 
+# Support segments
+@recipe f(::Type{Vector{T}}, dt::Vector{T}) where {T<:DateTime} = 
+    (dt -> Dates.value.(dt), datetimeformatter)
+@recipe f(::Type{Vector{T}}, dt::Vector{T}) where {T<:Date} = 
+    (dt -> Dates.value.(dt), dateformatter)
+@recipe f(::Type{Vector{T}}, dt::Vector{T}) where {T<:Time} = 
+    (dt -> Dates.value.(dt), timeformatter)
+
+
 # -------------------------------------------------
 # ## Characters
 


### PR DESCRIPTION
In Plots at some point there was a switch in how representing how segments were handled going from: 

```
[1.0, 1.0, NaN, 1.0, 1.0, NaN, 1.0, 1.0, NaN]
```
To: 

```
[[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]]
```

In Intervals, recipes are used to plot the segments for each Interval. So these segments look like: 

```
[[DateTime("2017-01-01T00:00:00"), DateTime("2017-01-01T01:00:00")], [DateTime("2017-01-01T01:00:00"), DateTime("2017-01-01T02:00:00")]
```

I have an [MR](https://github.com/invenia/Intervals.jl/pull/165) that updated that, however I've found that it was not working when using such DateTime types. I believe the issue is here. I'm not too sure on the internals of the package, but I believe that we need to add these methods, and top of these original recipes: 

```
@recipe f(::Type{DateTime}, dt::DateTime) = # Existing 
    (dt -> Dates.value(dt), datetimeformatter)
@recipe f(::Type{Vector{T}}, dt::Vector{T}) where {T<:DateTime} = 
    (dt -> Dates.value.(dt), datetimeformatter) # New method
```

This MR simply adds these. Testing with my branch in Intervals, this does create the correct plots. It is unclear whether additional tests are needed, as it looks like this uses a test suite from Plots. 

Related: 
https://github.com/invenia/Intervals.jl/issues/159


*****