### PR TITLE
More efficient DefaultDict iteration

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,9 +33,7 @@ function Base.delete!(dd::DefaultsDict, k)
 end
 Base.length(dd::DefaultsDict) = length(union(keys(dd.explicit), keys(dd.defaults)))
 function Base.iterate(dd::DefaultsDict)
-    exp_keys = keys(dd.explicit)
-    def_keys = setdiff(keys(dd.defaults), exp_keys)
-    key_list = collect(Iterators.flatten((exp_keys, def_keys)))
+    key_list = union!(collect(keys(dd.explicit)), keys(dd.defaults))
     iterate(dd, (key_list, 1))
 end
 function Base.iterate(dd::DefaultsDict, (key_list, i))


### PR DESCRIPTION
The current DefaultDict iteration is extremely expensive, mostly due to reliance on `Iterators.flatten`. This change cuts many of these excessive allocations. See: https://github.com/JuliaPlots/Plots.jl/issues/4237#issuecomment-1264185227

Although it would be even better if we didn't have to preserve the order. Do we? `collect(union(x, y))` is a bit more memory efficient, at the cost of lost order. But the current PR preserves exactly what the current code does.