### PR TITLE
DefaultsDict - correctness and performance tweaks for large numbers of series

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,6 +30,7 @@ end
 function Base.delete!(dd::DefaultsDict, k)
     haskey(dd.explicit, k) && delete!(dd.explicit, k)
     haskey(dd.defaults, k) && delete!(dd.defaults, k)
+    return dd
 end
 Base.length(dd::DefaultsDict) = length(union(keys(dd.explicit), keys(dd.defaults)))
 function Base.iterate(dd::DefaultsDict)
@@ -50,7 +51,10 @@ isdefault(dd::DefaultsDict, k) = !is_explicit(dd, k) && haskey(dd.defaults, k)
 Base.setindex!(dd::DefaultsDict, v, k) = dd.explicit[k] = v
 
 # Reset to default value and return dict
-reset_kw!(dd::DefaultsDict, k) = is_explicit(dd, k) ? delete!(dd.explicit, k) : dd
+function reset_kw!(dd::DefaultsDict, k)
+    is_explicit(dd, k) && delete!(dd.explicit, k)
+    return dd
+end
 # Reset to default value and return old value
 pop_kw!(dd::DefaultsDict, k) = is_explicit(dd, k) ? pop!(dd.explicit, k) : dd.defaults[k]
 pop_kw!(dd::DefaultsDict, k, default) =

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -51,7 +51,7 @@ isdefault(dd::DefaultsDict, k) = !is_explicit(dd, k) && haskey(dd.defaults, k)
 Base.setindex!(dd::DefaultsDict, v, k) = dd.explicit[k] = v
 
 # Reset to default value and return dict
-@inline function reset_kw!(dd::DefaultsDict, k)
+function reset_kw!(dd::DefaultsDict, k)
     is_explicit(dd, k) && delete!(dd.explicit, k)
     return dd
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -51,7 +51,7 @@ isdefault(dd::DefaultsDict, k) = !is_explicit(dd, k) && haskey(dd.defaults, k)
 Base.setindex!(dd::DefaultsDict, v, k) = dd.explicit[k] = v
 
 # Reset to default value and return dict
-function reset_kw!(dd::DefaultsDict, k)
+@inline function reset_kw!(dd::DefaultsDict, k)
     is_explicit(dd, k) && delete!(dd.explicit, k)
     return dd
 end


### PR DESCRIPTION
Test example:
```
const xxxx = rand(10, 10000) # lots of small series
plot(xxxx);
```

Noticed that the `delete!` methods were sometimes returning an underlying dictionary rather than the `DefaultDict` itself; improved type stability resulted in large reduction in allocation count:
`825.900 ms (5210177 allocations: 255.31 MiB)`
to
`814.990 ms (4470177 allocations: 232.73 MiB)`